### PR TITLE
feat: add inline status messages

### DIFF
--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
-import { 
-  Users, 
-  Settings, 
-  Eye, 
-  Edit3, 
-  Trash2, 
-  Plus, 
-  Search, 
+import {
+  Users,
+  Settings,
+  Eye,
+  Edit3,
+  Trash2,
+  Plus,
+  Search,
   Filter,
   MoreVertical,
   Shield,
@@ -19,11 +19,9 @@ import {
   TrendingUp,
   FileText,
   Zap,
-  LogIn,
-  AlertCircle,
-  CheckCircle,
-  X
+  LogIn
 } from 'lucide-react';
+import StatusMessage from './StatusMessage';
 
 export default function AdminDashboard() {
   const [organizations, setOrganizations] = useState([]);
@@ -32,6 +30,14 @@ export default function AdminDashboard() {
   const [statusFilter, setStatusFilter] = useState('all');
   const [selectedOrgs, setSelectedOrgs] = useState([]);
   const [showAddModal, setShowAddModal] = useState(false);
+  const [status, setStatus] = useState({ type: '', message: '' });
+
+  useEffect(() => {
+    if (status.message) {
+      const timer = setTimeout(() => setStatus({ type: '', message: '' }), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [status]);
 
   useEffect(() => {
     fetchOrganizations();
@@ -129,7 +135,7 @@ export default function AdminDashboard() {
 
   const handleBulkAction = async (action) => {
     console.log(`Bulk ${action} for organizations:`, selectedOrgs);
-    
+
     try {
       if (action === 'suspend') {
         // Update organizations status to suspended
@@ -140,12 +146,14 @@ export default function AdminDashboard() {
         
         if (error) throw error;
       }
-      
+
       // Refresh data and clear selection
       await fetchOrganizations();
       setSelectedOrgs([]);
+      setStatus({ type: 'success', message: `Bulk ${action} completed successfully.` });
     } catch (error) {
       console.error(`Error performing bulk ${action}:`, error);
+      setStatus({ type: 'error', message: `Error performing bulk ${action}.` });
     }
   };
 
@@ -267,9 +275,10 @@ export default function AdminDashboard() {
         await fetchOrganizations();
         setShowAddModal(false);
         setFormData({ name: '', industry: '', contact_email: '', contact_name: '' });
+        setStatus({ type: 'success', message: 'Client created successfully.' });
       } catch (error) {
         console.error('Error creating organization:', error);
-        alert('Error creating client. Please try again.');
+        setStatus({ type: 'error', message: 'Error creating client. Please try again.' });
       } finally {
         setSaving(false);
       }
@@ -376,6 +385,8 @@ export default function AdminDashboard() {
           </div>
         </div>
       </div>
+
+      <StatusMessage type={status.type} message={status.message} />
 
       {/* Quick Stats */}
       <div className="grid grid-cols-1 gap-5 sm:grid-cols-4 mb-8">

--- a/src/components/LoginPage.jsx
+++ b/src/components/LoginPage.jsx
@@ -1,35 +1,43 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
+import StatusMessage from './StatusMessage';
 
 export default function LoginPage() {
   const [isSignUp, setIsSignUp] = useState(false);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const [status, setStatus] = useState({ type: '', message: '' });
+
+  useEffect(() => {
+    if (status.message) {
+      const timer = setTimeout(() => setStatus({ type: '', message: '' }), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [status]);
 
   const logoUrl = "https://ibbkdeptefqazanswvqj.supabase.co/storage/v1/object/public/public-assets/mkt.png";
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setLoading(true);
-    setError(null);
+      setLoading(true);
+      setStatus({ type: '', message: '' });
 
     try {
       if (isSignUp) {
-        const { error } = await supabase.auth.signUp({ email, password });
-        if (error) throw error;
-        alert('Check your email for confirmation!');
-      } else {
-        const { error } = await supabase.auth.signInWithPassword({ email, password });
-        if (error) throw error;
+          const { error } = await supabase.auth.signUp({ email, password });
+          if (error) throw error;
+          setStatus({ type: 'success', message: 'Check your email for confirmation!' });
+        } else {
+          const { error } = await supabase.auth.signInWithPassword({ email, password });
+          if (error) throw error;
+        }
+      } catch (error) {
+        setStatus({ type: 'error', message: error.message });
+      } finally {
+        setLoading(false);
       }
-    } catch (error) {
-      setError(error.message);
-    } finally {
-      setLoading(false);
-    }
-  };
+    };
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
@@ -49,11 +57,7 @@ export default function LoginPage() {
           </h2>
         </div>
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-          {error && (
-            <div className="bg-red-50 text-red-500 p-3 rounded-md text-sm">
-              {error}
-            </div>
-          )}
+            {status.message && <StatusMessage type={status.type} message={status.message} />}
           <div className="rounded-md shadow-sm -space-y-px">
             <div>
               <input

--- a/src/components/StatusMessage.jsx
+++ b/src/components/StatusMessage.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { AlertCircle, CheckCircle } from 'lucide-react';
+
+export default function StatusMessage({ type = 'success', message }) {
+  if (!message) return null;
+  const isError = type === 'error';
+  const classes = isError
+    ? 'bg-red-50 text-red-800 border-red-200'
+    : 'bg-green-50 text-green-800 border-green-200';
+  const Icon = isError ? AlertCircle : CheckCircle;
+
+  return (
+    <div className={`mb-4 flex items-center border ${classes} px-4 py-3 rounded-md`}>
+      <Icon className="h-5 w-5 mr-2" />
+      <span className="text-sm">{message}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `StatusMessage` component for success and error feedback
- use inline status in admin dashboard for client creation and bulk actions
- replace sign-up alert with status message on login page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a24d4161708329893ea4d8442c9dd6