### PR TITLE
Make admin headers responsive

### DIFF
--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -327,7 +327,7 @@ export default function AdminDashboard() {
       <div className="fixed inset-0 bg-gray-500 bg-opacity-75 flex items-center justify-center z-50">
         <div className="bg-white rounded-lg max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto">
           <div className="p-6 border-b border-gray-200">
-            <div className="flex items-center justify-between">
+            <div className="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:justify-between sm:items-center">
               <h2 className="text-xl font-semibold text-gray-900">
                 Edit Branding - {selectedOrgForEdit.name}
               </h2>
@@ -649,7 +649,7 @@ export default function AdminDashboard() {
       {/* Clients List */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-200">
         <div className="p-6 border-b border-gray-200">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:justify-between sm:items-center">
             <h2 className="text-xl font-semibold text-gray-900">Client Organizations</h2>
             <button
               onClick={() => setShowAddModal(true)}


### PR DESCRIPTION
## Summary
- Stack admin section headers vertically on mobile and horizontally on larger screens
- Ensure branding modal header adapts responsively

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f35225708329936eb20f991c26c0