### PR TITLE
Add AI Scoring navigation link

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -145,14 +145,34 @@ export default function Layout() {
                         : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
                     }`
                   }
-                  style={({ isActive }) => 
-                    isActive && branding?.primary_color 
+                  style={({ isActive }) =>
+                    isActive && branding?.primary_color
                       ? { borderBottomColor: branding.primary_color, color: branding.primary_color }
                       : undefined
                   }
                 >
                   Analytics
                 </NavLink>
+
+                {features.lead_scoring !== false && (
+                  <NavLink
+                    to="/scoring"
+                    className={({ isActive }) =>
+                      `inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                        isActive
+                          ? 'border-orange-500 text-gray-900'
+                          : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
+                      }`
+                    }
+                    style={({ isActive }) =>
+                      isActive && branding?.primary_color
+                        ? { borderBottomColor: branding.primary_color, color: branding.primary_color }
+                        : undefined
+                    }
+                  >
+                    AI Scoring
+                  </NavLink>
+                )}
 
                 {features.chatbots !== false && (
                   <NavLink
@@ -267,6 +287,22 @@ export default function Layout() {
               >
                 Analytics
               </NavLink>
+
+              {features.lead_scoring !== false && (
+                <NavLink
+                  to="/scoring"
+                  className={({ isActive }) =>
+                    `block pl-3 pr-4 py-2 border-l-4 text-base font-medium ${
+                      isActive
+                        ? 'bg-orange-50 border-orange-500 text-orange-700'
+                        : 'border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700'
+                    }`
+                  }
+                  onClick={() => setMobileMenuOpen(false)}
+                >
+                  AI Scoring
+                </NavLink>
+              )}
 
               {features.chatbots !== false && (
                 <NavLink


### PR DESCRIPTION
## Summary
- Add AI Scoring nav link to desktop and mobile layouts when `lead_scoring` feature is enabled

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ce8ef5248329a1887c20c1f44769