### PR TITLE
Display LinkedIn profile picture on lead profile card

### DIFF
--- a/src/components/LeadProfile.jsx
+++ b/src/components/LeadProfile.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Building2, MapPin } from 'lucide-react';
+
+export default function LeadProfile({ lead }) {
+  return (
+    <div className="bg-white shadow rounded-lg overflow-hidden">
+      <div className="bg-gradient-to-r from-blue-600 to-blue-700 h-24"></div>
+      <div className="px-6 pb-6 -mt-12">
+        <div className="flex items-start space-x-4">
+          <div className="flex-shrink-0">
+            {lead.linkedin_profile_picture ? (
+              <img
+                src={lead.linkedin_profile_picture}
+                alt={`${lead.first_name || ''} ${lead.last_name || ''}`.trim()}
+                className="w-32 h-32 rounded-full border-4 border-white shadow-lg object-cover"
+              />
+            ) : (
+              <div className="w-32 h-32 rounded-full border-4 border-white shadow-lg bg-orange-500 flex items-center justify-center text-white text-2xl font-bold">
+                {(lead.first_name || 'U')[0]}
+                {(lead.last_name || 'L')[0]}
+              </div>
+            )}
+          </div>
+          <div className="flex-grow pt-4">
+            <h2 className="text-2xl font-bold text-gray-900">
+              {lead.first_name || 'Unknown'} {lead.last_name || 'Lead'}
+            </h2>
+            {lead.headline && (
+              <p className="text-gray-600 mt-1 text-sm">{lead.headline}</p>
+            )}
+            <div className="flex flex-wrap items-center mt-2 gap-3 text-sm text-gray-500">
+              {lead.current_company && (
+                <span className="flex items-center">
+                  <Building2 className="h-4 w-4 mr-1" />
+                  {lead.current_company}
+                </span>
+              )}
+              {lead.location && (
+                <span className="flex items-center">
+                  <MapPin className="h-4 w-4 mr-1" />
+                  {lead.location}
+                </span>
+              )}
+            </div>
+            {(lead.connections || lead.followers) && (
+              <div className="flex items-center mt-3 space-x-4 text-sm">
+                {lead.connections && (
+                  <span className="text-blue-600 font-medium">
+                    {lead.connections.toLocaleString()} connections
+                  </span>
+                )}
+                {lead.followers && (
+                  <span className="text-blue-600 font-medium">
+                    {lead.followers.toLocaleString()} followers
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
+          <div className="flex-shrink-0 pt-4">
+            <div className="text-center">
+              <div
+                className={`inline-flex items-center justify-center w-20 h-20 rounded-full text-white text-2xl font-bold ${
+                  lead.ai_score >= 75
+                    ? 'bg-green-500'
+                    : lead.ai_score >= 55
+                    ? 'bg-yellow-500'
+                    : 'bg-red-500'
+                }`}
+              >
+                {lead.ai_score || 0}
+              </div>
+              <p className="text-sm font-medium text-gray-600 mt-2">
+                {lead.lead_tier || 'Not Scored'}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/ScoringConfigPage.jsx
+++ b/src/components/ScoringConfigPage.jsx
@@ -11,6 +11,7 @@ import {
   AlertCircle,
   Zap
 } from 'lucide-react';
+import LeadProfile from './LeadProfile';
 
 export default function ScoringConfigPage() {
   const { organization } = useOrganization();
@@ -124,7 +125,8 @@ export default function ScoringConfigPage() {
       }
 
       const data = await response.json();
-      setTestResults(data);
+      const leadData = data.lead || data;
+      setTestResults(leadData);
     } catch (err) {
       console.error('Error testing lead:', err);
       if (err.message.includes('Failed to fetch')) {
@@ -546,77 +548,7 @@ export default function ScoringConfigPage() {
               {/* Results Display */}
               {testResults && !isLoading && (
                 <div className="space-y-4 animate-fadeIn">
-                  {/* LinkedIn-style Profile Card */}
-                  <div className="bg-white shadow rounded-lg overflow-hidden">
-                    {/* Header Background */}
-                    <div className="bg-gradient-to-r from-blue-600 to-blue-700 h-24"></div>
-                    
-                    {/* Profile Content */}
-                    <div className="px-6 pb-6 -mt-12">
-                      <div className="flex items-start space-x-4">
-                        {/* Profile Picture - SIMPLE VERSION */}
-                        <div className="flex-shrink-0">
-                          <div className="w-24 h-24 rounded-full border-4 border-white shadow-lg bg-orange-500 flex items-center justify-center text-white text-2xl font-bold">
-                            {(testResults.first_name || 'U')[0]}{(testResults.last_name || 'U')[0]}
-                          </div>
-                        </div>
-                        
-                        {/* Name and Details */}
-                        <div className="flex-grow pt-4">
-                          <h2 className="text-2xl font-bold text-gray-900">
-                            {testResults.first_name || 'Unknown'} {testResults.last_name || 'Lead'}
-                          </h2>
-                          {testResults.headline && (
-                            <p className="text-gray-600 mt-1 text-sm">{testResults.headline}</p>
-                          )}
-                          <div className="flex flex-wrap items-center mt-2 gap-3 text-sm text-gray-500">
-                            {testResults.current_company && (
-                              <span className="flex items-center">
-                                <Building2 className="h-4 w-4 mr-1" />
-                                {testResults.current_company}
-                              </span>
-                            )}
-                            {testResults.location && (
-                              <span className="flex items-center">
-                                <MapPin className="h-4 w-4 mr-1" />
-                                {testResults.location}
-                              </span>
-                            )}
-                          </div>
-                          
-                          {/* Network Stats */}
-                          {(testResults.connections || testResults.followers) && (
-                            <div className="flex items-center mt-3 space-x-4 text-sm">
-                              {testResults.connections && (
-                                <span className="text-blue-600 font-medium">
-                                  {testResults.connections.toLocaleString()} connections
-                                </span>
-                              )}
-                              {testResults.followers && (
-                                <span className="text-blue-600 font-medium">
-                                  {testResults.followers.toLocaleString()} followers
-                                </span>
-                              )}
-                            </div>
-                          )}
-                        </div>
-                        
-                        {/* Score Badge */}
-                        <div className="flex-shrink-0 pt-4">
-                          <div className="text-center">
-                            <div className={`inline-flex items-center justify-center w-20 h-20 rounded-full text-white text-2xl font-bold
-                              ${testResults.ai_score >= 75 ? 'bg-green-500' :
-                                testResults.ai_score >= 55 ? 'bg-yellow-500' : 'bg-red-500'}`}>
-                              {testResults.ai_score || 0}
-                            </div>
-                            <p className="text-sm font-medium text-gray-600 mt-2">
-                              {testResults.lead_tier || 'Not Scored'}
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
+                  <LeadProfile lead={testResults} />
 
                   {/* Financial Qualification Card */}
                   <div className="bg-white shadow rounded-lg p-4">


### PR DESCRIPTION
## Summary
- add reusable `LeadProfile` component to show lead details and LinkedIn avatar
- integrate `LeadProfile` into scoring results and ensure API response includes LinkedIn picture

## Testing
- `npm run lint` (fails: ESLint couldn't find a configuration file)
- `node test-lead-profile.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68a568054bb48329bb205ed3e9861663