### PR TITLE
Add iframe chat HTML

### DIFF
--- a/public/chat-iframe.html
+++ b/public/chat-iframe.html
@@ -1,0 +1,459 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Chat Assistant</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        html, body {
+            height: 100%;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            overflow: hidden;
+        }
+        
+        .chat-container {
+            height: 100vh;
+            display: flex;
+            flex-direction: column;
+            background: #f9fafb;
+        }
+        
+        .chat-header {
+            background: #3B82F6;
+            color: white;
+            padding: 16px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            flex-shrink: 0;
+        }
+        
+        .status-dot {
+            width: 8px;
+            height: 8px;
+            background: #10B981;
+            border-radius: 50%;
+        }
+        
+        .chat-messages {
+            flex: 1;
+            overflow-y: auto;
+            padding: 16px;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+        
+        .message {
+            display: flex;
+        }
+        
+        .message.user {
+            justify-content: flex-end;
+        }
+        
+        .message.assistant {
+            justify-content: flex-start;
+        }
+        
+        .message-bubble {
+            max-width: 80%;
+            padding: 12px 16px;
+            border-radius: 16px;
+            font-size: 14px;
+            line-height: 1.4;
+            word-wrap: break-word;
+        }
+        
+        .message.user .message-bubble {
+            background: #3B82F6;
+            color: white;
+            border-bottom-right-radius: 4px;
+        }
+        
+        .message.assistant .message-bubble {
+            background: white;
+            color: #374151;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+            border-bottom-left-radius: 4px;
+        }
+        
+        .message.error .message-bubble {
+            background: #FEF2F2;
+            color: #DC2626;
+            border: 1px solid #FECACA;
+        }
+        
+        .chat-input {
+            background: white;
+            padding: 16px;
+            border-top: 1px solid #E5E7EB;
+            display: flex;
+            gap: 8px;
+            flex-shrink: 0;
+        }
+        
+        .input-field {
+            flex: 1;
+            padding: 12px;
+            border: 1px solid #D1D5DB;
+            border-radius: 8px;
+            resize: none;
+            font-family: inherit;
+            font-size: 14px;
+            min-height: 44px;
+            max-height: 100px;
+        }
+        
+        .input-field:focus {
+            outline: none;
+            border-color: #3B82F6;
+            box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+        }
+        
+        .send-button {
+            padding: 12px;
+            background: #3B82F6;
+            color: white;
+            border: none;
+            border-radius: 8px;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 16px;
+            min-width: 44px;
+            transition: background-color 0.2s;
+        }
+        
+        .send-button:hover {
+            background: #2563EB;
+        }
+        
+        .send-button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+        
+        .typing-indicator {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 12px 16px;
+            background: white;
+            border-radius: 16px;
+            border-bottom-left-radius: 4px;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        }
+        
+        .typing-dots {
+            display: flex;
+            gap: 4px;
+        }
+        
+        .typing-dot {
+            width: 6px;
+            height: 6px;
+            background: #9CA3AF;
+            border-radius: 50%;
+            animation: typing 1.4s infinite;
+        }
+        
+        .typing-dot:nth-child(2) {
+            animation-delay: 0.2s;
+        }
+        
+        .typing-dot:nth-child(3) {
+            animation-delay: 0.4s;
+        }
+        
+        @keyframes typing {
+            0%, 60%, 100% {
+                transform: translateY(0);
+            }
+            30% {
+                transform: translateY(-8px);
+            }
+        }
+        
+        .loading-message {
+            text-align: center;
+            color: #6B7280;
+            padding: 32px;
+        }
+        
+        .error-message {
+            text-align: center;
+            color: #DC2626;
+            padding: 32px;
+            background: #FEF2F2;
+            border: 1px solid #FECACA;
+            border-radius: 8px;
+            margin: 16px;
+        }
+        
+        @media (max-width: 480px) {
+            .chat-messages {
+                padding: 12px;
+                gap: 12px;
+            }
+            
+            .message-bubble {
+                max-width: 90%;
+            }
+            
+            .chat-input {
+                padding: 12px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="chat-container">
+        <div class="chat-header">
+            <span>🤖</span>
+            <span id="bot-name" style="font-weight: 500;">AI Assistant</span>
+            <div class="status-dot"></div>
+        </div>
+        
+        <div class="chat-messages" id="messages">
+            <div class="loading-message" id="loading">
+                Loading chat...
+            </div>
+        </div>
+        
+        <div class="chat-input">
+            <textarea 
+                id="message-input" 
+                class="input-field" 
+                placeholder="Type your message..."
+                rows="1"
+                disabled
+            ></textarea>
+            <button id="send-button" class="send-button" disabled>
+                ➤
+            </button>
+        </div>
+    </div>
+    
+    <script src="https://unpkg.com/@supabase/supabase-js@2/dist/umd/supabase.js"></script>
+    <script>
+        // Configuration - UPDATE THESE VALUES
+        const CONFIG = {
+            supabaseUrl: 'https://ibbkdeptefqazanswvqj.supabase.co',
+            supabaseAnonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImliYmtkZXB0ZWZxYXphbnN3dnFqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUzMTMzNzMsImV4cCI6MjA3MDg4OTM3M30.-1YXyUqo29q5eaFwUizDBVf1FqK_NZGNxNA9bCNXrMU'
+        };
+        
+        // Extract chatbot ID from URL
+        const urlParams = new URLSearchParams(window.location.search);
+        const chatbotId = urlParams.get('chatbot') || window.location.pathname.split('/').pop();
+        
+        if (!chatbotId) {
+            showError('No chatbot ID provided');
+        }
+        
+        // Initialize Supabase
+        const supabase = window.supabase.createClient(CONFIG.supabaseUrl, CONFIG.supabaseAnonKey);
+        
+        // State
+        let messages = [];
+        let isLoading = false;
+        let sessionId = generateSessionId();
+        let conversationId = null;
+        let chatbotData = null;
+        
+        // DOM elements
+        const messagesContainer = document.getElementById('messages');
+        const messageInput = document.getElementById('message-input');
+        const sendButton = document.getElementById('send-button');
+        const loadingDiv = document.getElementById('loading');
+        
+        // Generate session ID
+        function generateSessionId() {
+            return `iframe-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+        }
+        
+        // Initialize chat
+        async function init() {
+            try {
+                // Load chatbot data
+                await loadChatbotData();
+                
+                // Remove loading message
+                loadingDiv.remove();
+                
+                // Add welcome message
+                addMessage('assistant', chatbotData?.welcome_message || 'Hi! How can I help you today?');
+                
+                // Enable input
+                messageInput.disabled = false;
+                sendButton.disabled = false;
+                messageInput.focus();
+                
+                // Setup event listeners
+                messageInput.addEventListener('keypress', handleKeyPress);
+                sendButton.addEventListener('click', sendMessage);
+                
+                // Auto-resize textarea
+                messageInput.addEventListener('input', autoResize);
+                
+            } catch (error) {
+                console.error('Initialization error:', error);
+                showError('Failed to initialize chat');
+            }
+        }
+        
+        // Load chatbot configuration
+        async function loadChatbotData() {
+            const { data, error } = await supabase
+                .from('chatbots')
+                .select('name, welcome_message, settings, organization_id')
+                .eq('id', chatbotId)
+                .eq('is_active', true)
+                .single();
+            
+            if (error) throw error;
+            
+            chatbotData = data;
+            
+            // Update header with chatbot name
+            document.getElementById('bot-name').textContent = data.name || 'AI Assistant';
+            document.title = `Chat with ${data.name || 'AI Assistant'}`;
+        }
+        
+        // Handle key press
+        function handleKeyPress(event) {
+            if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault();
+                sendMessage();
+            }
+        }
+        
+        // Auto-resize textarea
+        function autoResize() {
+            messageInput.style.height = 'auto';
+            messageInput.style.height = Math.min(messageInput.scrollHeight, 100) + 'px';
+        }
+        
+        // Send message
+        async function sendMessage() {
+            const message = messageInput.value.trim();
+            if (!message || isLoading) return;
+            
+            // Add user message
+            addMessage('user', message);
+            messageInput.value = '';
+            messageInput.style.height = 'auto';
+            
+            // Show typing indicator
+            showTypingIndicator();
+            isLoading = true;
+            sendButton.disabled = true;
+            
+            try {
+                // Call Supabase Edge Function
+                const { data, error } = await supabase.functions.invoke('chat', {
+                    body: {
+                        message: message,
+                        chatbotId: chatbotId,
+                        sessionId: sessionId,
+                        conversationId: conversationId
+                    }
+                });
+                
+                if (error) throw error;
+                
+                // Update conversation ID
+                if (!conversationId && data.conversationId) {
+                    conversationId = data.conversationId;
+                }
+                
+                // Add assistant response
+                hideTypingIndicator();
+                addMessage('assistant', data.response);
+                
+            } catch (error) {
+                console.error('Send message error:', error);
+                hideTypingIndicator();
+                addMessage('assistant', 'Sorry, I encountered an error. Please try again.', true);
+            } finally {
+                isLoading = false;
+                sendButton.disabled = false;
+                messageInput.focus();
+            }
+        }
+        
+        // Add message to chat
+        function addMessage(role, content, error = false) {
+            const message = { role, content, timestamp: Date.now(), error };
+            messages.push(message);
+            renderMessage(message);
+            scrollToBottom();
+        }
+        
+        // Render message
+        function renderMessage(message) {
+            const messageDiv = document.createElement('div');
+            messageDiv.className = `message ${message.role}${message.error ? ' error' : ''}`;
+            
+            const bubble = document.createElement('div');
+            bubble.className = 'message-bubble';
+            bubble.textContent = message.content;
+            
+            messageDiv.appendChild(bubble);
+            messagesContainer.appendChild(messageDiv);
+        }
+        
+        // Show typing indicator
+        function showTypingIndicator() {
+            const typingDiv = document.createElement('div');
+            typingDiv.className = 'message assistant';
+            typingDiv.id = 'typing-indicator';
+            
+            const indicator = document.createElement('div');
+            indicator.className = 'typing-indicator';
+            indicator.innerHTML = `
+                <div class="typing-dots">
+                    <div class="typing-dot"></div>
+                    <div class="typing-dot"></div>
+                    <div class="typing-dot"></div>
+                </div>
+                <span style="font-size: 12px; color: #6B7280;">AI is typing...</span>
+            `;
+            
+            typingDiv.appendChild(indicator);
+            messagesContainer.appendChild(typingDiv);
+            scrollToBottom();
+        }
+        
+        // Hide typing indicator
+        function hideTypingIndicator() {
+            const indicator = document.getElementById('typing-indicator');
+            if (indicator) indicator.remove();
+        }
+        
+        // Scroll to bottom
+        function scrollToBottom() {
+            messagesContainer.scrollTop = messagesContainer.scrollHeight;
+        }
+        
+        // Show error
+        function showError(message) {
+            messagesContainer.innerHTML = `
+                <div class="error-message">
+                    <strong>Error:</strong> ${message}
+                </div>
+            `;
+        }
+        
+        // Start when page loads
+        document.addEventListener('DOMContentLoaded', init);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `chat-iframe.html` in `public` for embedding a Supabase-powered chat assistant
- configure Supabase client with project URL and anon key

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a941baefd083298ab7c5749cb72743