### PR TITLE
Rename ChatbotBuilder to ChatbotConversations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,7 @@ import LoginPage from './components/LoginPage';
 import Dashboard from './components/Dashboard';
 import LeadsPage from './components/LeadsPage';
 import AnalyticsPage from './components/AnalyticsPage';
-import ChatbotBuilder from './components/ChatbotBuilder';
+import ChatbotConversations from './components/ChatbotConversations';
 import AdminDashboard from './components/AdminDashboard';
 import ScoringConfigPage from './components/ScoringConfigPage';
 import OnboardingWizard from './components/OnboardingWizard';
@@ -127,7 +127,7 @@ export default function App() {
                 path="chatbots" 
                 element={
                   <ProtectedFeatureRoute feature="chatbots">
-                    <ChatbotBuilder />
+                    <ChatbotConversations />
                   </ProtectedFeatureRoute>
                 } 
               />

--- a/src/components/ChatbotConversations.jsx
+++ b/src/components/ChatbotConversations.jsx
@@ -24,7 +24,7 @@ import {
   Send
 } from 'lucide-react';
 
-export default function ChatbotBuilder() {
+export default function ChatbotConversations() {
   const { organization, branding } = useOrganization();
   const [activeTab, setActiveTab] = useState('conversations');
   const [conversations, setConversations] = useState([]);


### PR DESCRIPTION
## Summary
- Rename ChatbotBuilder component to ChatbotConversations and update its export.
- Update App.jsx to import and render ChatbotConversations.

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9532c09c08329835d9581b23f5f3b