### PR TITLE
Add chatbot conversation routing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import LoginPage from './components/LoginPage';
 import Dashboard from './components/Dashboard';
 import LeadsPage from './components/LeadsPage';
 import AnalyticsPage from './components/AnalyticsPage';
+import ChatbotBuilder from './components/ChatbotBuilder';
 import ChatbotConversations from './components/ChatbotConversations';
 import AdminDashboard from './components/AdminDashboard';
 import ScoringConfigPage from './components/ScoringConfigPage';
@@ -125,6 +126,15 @@ export default function App() {
               {/* Feature-gated routes */}
               <Route 
                 path="chatbots" 
+                element={
+                  <ProtectedFeatureRoute feature="chatbots">
+                    <ChatbotBuilder />
+                  </ProtectedFeatureRoute>
+                } 
+              />
+
+              <Route 
+                path="chatbots/:id/conversations" 
                 element={
                   <ProtectedFeatureRoute feature="chatbots">
                     <ChatbotConversations />

--- a/src/components/ChatbotConversations.jsx
+++ b/src/components/ChatbotConversations.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
 import { useOrganization } from '../contexts/OrganizationContext';
+import { useParams } from 'react-router-dom';
 import { 
   MessageSquare, 
   ChevronDown, 
@@ -39,6 +40,8 @@ export default function ChatbotConversations() {
     avgSatisfaction: 0,
     todayCount: 0
   });
+
+  const { id } = useParams();
   
   // ENHANCED AGNT Configuration State
   const [agntConfig, setAgntConfig] = useState({
@@ -184,6 +187,7 @@ export default function ChatbotConversations() {
       const { data: chatbots } = await supabase
         .from('chatbots')
         .select('id, name')
+        .eq('id', id)
         .eq('organization_id', organization.id);
       
       const chatbotIds = chatbots?.map(c => c.id) || [];


### PR DESCRIPTION
## Summary
- add ChatbotBuilder and ChatbotConversations routes to support viewing chatbot conversations
- use URL params in ChatbotConversations to fetch conversations for a specific bot

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a955985de883299bf855e59c729c9b