### PR TITLE
Remove legacy chatbot conversations route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,6 @@ import Dashboard from './components/Dashboard';
 import LeadsPage from './components/LeadsPage';
 import AnalyticsPage from './components/AnalyticsPage';
 import ChatbotBuilder from './components/ChatbotBuilder';
-import ChatbotConversations from './components/ChatbotConversations';
 import AdminDashboard from './components/AdminDashboard';
 import ScoringConfigPage from './components/ScoringConfigPage';
 import OnboardingWizard from './components/OnboardingWizard';
@@ -124,22 +123,13 @@ export default function App() {
               <Route path="analytics" element={<AnalyticsPage />} />
               
               {/* Feature-gated routes */}
-              <Route 
-                path="chatbots" 
+              <Route
+                path="chatbots"
                 element={
                   <ProtectedFeatureRoute feature="chatbots">
                     <ChatbotBuilder />
                   </ProtectedFeatureRoute>
-                } 
-              />
-
-              <Route 
-                path="chatbots/:id/conversations" 
-                element={
-                  <ProtectedFeatureRoute feature="chatbots">
-                    <ChatbotConversations />
-                  </ProtectedFeatureRoute>
-                } 
+                }
               />
               
               <Route 

--- a/src/components/ChatbotBuilder.jsx
+++ b/src/components/ChatbotBuilder.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
 import { useOrganization } from '../contexts/OrganizationContext';
-import { useNavigate } from 'react-router-dom';
 import { 
   MessageSquare, ChevronDown, ChevronUp, Phone, MapPin,
   Building, Briefcase, Calendar, Star, Clock, User, Bot,
@@ -12,7 +11,6 @@ import {
 
 export default function ChatbotBuilder() {
   const { organization, branding } = useOrganization();
-  const navigate = useNavigate();
   
   // Main navigation state - now includes conversations as main tab
   const [mainTab, setMainTab] = useState('conversations');


### PR DESCRIPTION
## Summary
- drop ChatbotConversations route and import
- clean up unused navigation in ChatbotBuilder

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68abe02979148329a8c3f10230b5c748