### PR TITLE
Handle missing organization in TopicAnalyticsCard

### DIFF
--- a/src/components/AnalyticsPage.jsx
+++ b/src/components/AnalyticsPage.jsx
@@ -25,6 +25,7 @@ import {
 } from 'recharts';
 
 const TopicAnalyticsCard = ({ organization }) => {
+  if (!organization || !organization.id) return null;
   const [analysis, setAnalysis] = useState({
     trending: [],
     weekly: [],


### PR DESCRIPTION
## Summary
- Guard `TopicAnalyticsCard` against cases where no organization or ID is provided

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68abf74183b483299c537177dc95712a