### PR TITLE
Refactor leads page to card layout with expandable details

### DIFF
--- a/src/components/LeadsPage.jsx
+++ b/src/components/LeadsPage.jsx
@@ -303,14 +303,6 @@ export default function LeadsPage() {
                                 <span className="text-gray-900">{lead.company}</span>
                               </div>
                             )}
-                            {lead.ai_lead_id && (
-                              <div>
-                                <span className="text-gray-500">Lead ID: </span>
-                                <span className="text-gray-900 text-xs font-mono">
-                                  {lead.ai_lead_id.slice(0, 8)}...
-                                </span>
-                              </div>
-                            )}
                           </div>
 
                           {/* Conversation Link */}

--- a/src/components/LeadsPage.jsx
+++ b/src/components/LeadsPage.jsx
@@ -1,7 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabase';
 import { useOrganization } from '../contexts/OrganizationContext';
-import { Users, Search, Filter, Download, Plus } from 'lucide-react';
+import {
+  Users,
+  Search,
+  Download,
+  Plus,
+  ChevronDown,
+  ChevronUp,
+  Phone,
+  Mail,
+  MapPin,
+  Calendar,
+  MessageSquare
+} from 'lucide-react';
 
 export default function LeadsPage() {
   const { organization, loading: orgLoading } = useOrganization();
@@ -9,12 +21,12 @@ export default function LeadsPage() {
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
+  const [expandedLeads, setExpandedLeads] = useState(new Set());
 
   useEffect(() => {
     if (organization?.id && organization.id !== 'admin') {
       fetchLeads();
     } else if (!orgLoading && organization?.id === 'admin') {
-      // Admin without real org - show no leads
       setLeads([]);
       setLoading(false);
     }
@@ -24,7 +36,7 @@ export default function LeadsPage() {
     try {
       setLoading(true);
       console.log('Fetching leads for organization:', organization.id);
-      
+
       const { data, error } = await supabase
         .from('leads')
         .select('*')
@@ -32,7 +44,7 @@ export default function LeadsPage() {
         .order('created_at', { ascending: false });
 
       if (error) throw error;
-      
+
       console.log(`Found ${data?.length || 0} leads for org ${organization.id}`);
       setLeads(data || []);
     } catch (error) {
@@ -41,6 +53,18 @@ export default function LeadsPage() {
     } finally {
       setLoading(false);
     }
+  };
+
+  const toggleExpanded = (leadId) => {
+    setExpandedLeads((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(leadId)) {
+        newSet.delete(leadId);
+      } else {
+        newSet.add(leadId);
+      }
+      return newSet;
+    });
   };
 
   const getScoreColor = (score) => {
@@ -52,26 +76,46 @@ export default function LeadsPage() {
 
   const getStatusBadge = (status) => {
     const statusColors = {
-      'new': 'bg-blue-100 text-blue-800',
-      'contacted': 'bg-yellow-100 text-yellow-800',
-      'qualified': 'bg-green-100 text-green-800',
-      'converted': 'bg-purple-100 text-purple-800',
-      'lost': 'bg-red-100 text-red-800'
+      new: 'bg-blue-100 text-blue-800',
+      contacted: 'bg-yellow-100 text-yellow-800',
+      qualified: 'bg-green-100 text-green-800',
+      converted: 'bg-purple-100 text-purple-800',
+      lost: 'bg-red-100 text-red-800'
     };
     return statusColors[status] || 'bg-gray-100 text-gray-800';
   };
 
-  const filteredLeads = leads.filter(lead => {
-    const matchesSearch = 
+  const filteredLeads = leads.filter((lead) => {
+    const matchesSearch =
       lead.email?.toLowerCase().includes(searchTerm.toLowerCase()) ||
       lead.first_name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
       lead.last_name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      lead.company?.toLowerCase().includes(searchTerm.toLowerCase());
-    
+      lead.company?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      lead.phone?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      lead.location?.toLowerCase().includes(searchTerm.toLowerCase());
+
     const matchesStatus = statusFilter === 'all' || lead.status === statusFilter;
-    
+
     return matchesSearch && matchesStatus;
   });
+
+  const formatDate = (dateString) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    });
+  };
+
+  const formatPhone = (phone) => {
+    if (!phone) return 'Not provided';
+    const cleaned = phone.replace(/\D/g, '');
+    if (cleaned.length === 10) {
+      return `(${cleaned.slice(0, 3)}) ${cleaned.slice(3, 6)}-${cleaned.slice(6)}`;
+    }
+    return phone;
+  };
 
   if (orgLoading) {
     return (
@@ -84,123 +128,216 @@ export default function LeadsPage() {
   return (
     <div className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
       <div className="px-4 py-6 sm:px-0">
-        <div className="sm:flex sm:items-center sm:justify-between">
+        {/* Header */}
+        <div className="sm:flex sm:items-center sm:justify-between mb-6">
           <div className="sm:flex-auto">
             <h1 className="text-2xl font-bold text-gray-900">Leads</h1>
             <p className="mt-2 text-sm text-gray-700">
-              Manage and track your leads with AI-powered scoring
+              Manage and track your leads ({filteredLeads.length} total)
             </p>
           </div>
-          <div className="mt-4 sm:mt-0">
-            <button className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700">
+          <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+            <button className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-orange-600 hover:bg-orange-700">
               <Plus className="h-4 w-4 mr-2" />
               Add Lead
             </button>
           </div>
         </div>
 
-        {/* Filters */}
-        <div className="mt-6 flex flex-col sm:flex-row gap-4">
-          <div className="flex-1">
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-              <input
-                type="text"
-                placeholder="Search leads..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                className="pl-10 pr-4 py-2 w-full border border-gray-300 rounded-md"
-              />
-            </div>
+        {/* Search and Filter Bar */}
+        <div className="flex flex-col sm:flex-row gap-4 mb-6">
+          <div className="flex-1 relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+            <input
+              type="text"
+              placeholder="Search leads by name, email, phone, or location..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded-lg focus:ring-orange-500 focus:border-orange-500"
+            />
           </div>
-          <select
-            value={statusFilter}
-            onChange={(e) => setStatusFilter(e.target.value)}
-            className="px-4 py-2 border border-gray-300 rounded-md"
-          >
-            <option value="all">All Status</option>
-            <option value="new">New</option>
-            <option value="contacted">Contacted</option>
-            <option value="qualified">Qualified</option>
-            <option value="converted">Converted</option>
-            <option value="lost">Lost</option>
-          </select>
+          <div className="sm:w-48">
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-orange-500 focus:border-orange-500"
+            >
+              <option value="all">All Status</option>
+              <option value="new">New</option>
+              <option value="contacted">Contacted</option>
+              <option value="qualified">Qualified</option>
+              <option value="converted">Converted</option>
+              <option value="lost">Lost</option>
+            </select>
+          </div>
           <button className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
             <Download className="h-4 w-4 mr-2" />
             Export
           </button>
         </div>
 
-        {/* Leads Table */}
-        <div className="mt-8 flex flex-col">
-          <div className="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
-            <div className="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
-              <div className="overflow-hidden bg-white/95 backdrop-blur-sm rounded-3xl border border-white/80 shadow-lg hover:shadow-xl hover:-translate-y-2 transition-all duration-300 ring-1 ring-black ring-opacity-5">
-                <table className="min-w-full divide-y divide-gray-300">
-                  <thead className="bg-gray-50">
-                    <tr>
-                      <th className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Name</th>
-                      <th className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Email</th>
-                      <th className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Company</th>
-                      <th className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Score</th>
-                      <th className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Status</th>
-                      <th className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Created</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-gray-200 bg-white">
-                    {loading ? (
-                      <tr>
-                        <td colSpan="6" className="text-center py-4">Loading...</td>
-                      </tr>
-                    ) : filteredLeads.length === 0 ? (
-                      <tr>
-                        <td colSpan="6" className="text-center py-4 text-gray-500">
-                          {searchTerm || statusFilter !== 'all' 
-                            ? 'No leads match your filters' 
-                            : 'No leads yet. They will appear here when added.'}
-                        </td>
-                      </tr>
-                    ) : (
-                      filteredLeads.map((lead) => (
-                        <tr key={lead.id} className="hover:bg-gray-50">
-                          <td className="whitespace-nowrap px-3 py-4 text-sm">
-                            <div className="font-medium text-gray-900">
-                              {lead.first_name} {lead.last_name}
-                            </div>
-                          </td>
-                          <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                            {lead.email}
-                          </td>
-                          <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                            {lead.company || 'N/A'}
-                          </td>
-                          <td className="whitespace-nowrap px-3 py-4 text-sm">
-                            {lead.score ? (
-                              <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getScoreColor(lead.score)}`}>
-                                {lead.score}
-                              </span>
-                            ) : (
-                              <span className="text-gray-400">-</span>
-                            )}
-                          </td>
-                          <td className="whitespace-nowrap px-3 py-4 text-sm">
-                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getStatusBadge(lead.status)}`}>
-                              {lead.status || 'new'}
-                            </span>
-                          </td>
-                          <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                            {new Date(lead.created_at).toLocaleDateString()}
-                          </td>
-                        </tr>
-                      ))
-                    )}
-                  </tbody>
-                </table>
+        {/* Leads Cards */}
+        <div className="space-y-3">
+          {loading ? (
+            <div className="text-center py-12">
+              <div className="inline-flex items-center">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-600"></div>
+                <span className="ml-2">Loading leads...</span>
               </div>
             </div>
-          </div>
+          ) : filteredLeads.length === 0 ? (
+            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-12 text-center">
+              <Users className="mx-auto h-12 w-12 text-gray-400 mb-4" />
+              <p className="text-gray-500">
+                {searchTerm || statusFilter !== 'all'
+                  ? 'No leads match your filters'
+                  : 'No leads yet. They will appear here when added.'}
+              </p>
+            </div>
+          ) : (
+            filteredLeads.map((lead) => {
+              const isExpanded = expandedLeads.has(lead.id);
+              const fullName = `${lead.first_name || ''} ${lead.last_name || ''}`.trim() || 'Unknown';
+
+              return (
+                <div
+                  key={lead.id}
+                  className="bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md transition-all duration-200"
+                >
+                  {/* Collapsed View - Basic Info */}
+                  <div className="p-4 cursor-pointer" onClick={() => toggleExpanded(lead.id)}>
+                    <div className="flex items-center justify-between">
+                      <div className="flex-1">
+                        <div className="flex items-start justify-between">
+                          <div className="flex-1">
+                            {/* Name and Status Row */}
+                            <div className="flex items-center gap-3 mb-2">
+                              <h3 className="text-lg font-semibold text-gray-900">{fullName}</h3>
+                              <span
+                                className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getStatusBadge(
+                                  lead.status
+                                )}`}
+                              >
+                                {lead.status || 'new'}
+                              </span>
+                              {lead.score > 0 && (
+                                <span
+                                  className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getScoreColor(
+                                    lead.score
+                                  )}`}
+                                >
+                                  Score: {lead.score}
+                                </span>
+                              )}
+                            </div>
+
+                            {/* Contact Info Grid */}
+                            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+                              {/* Email */}
+                              <div className="flex items-center text-gray-600">
+                                <Mail className="h-4 w-4 mr-2 text-gray-400" />
+                                <span className="truncate">
+                                  {lead.email === 'not provided' ? 'No email' : lead.email}
+                                </span>
+                              </div>
+
+                              {/* Phone */}
+                              <div className="flex items-center text-gray-600">
+                                <Phone className="h-4 w-4 mr-2 text-gray-400" />
+                                <span>{formatPhone(lead.phone)}</span>
+                              </div>
+
+                              {/* Location */}
+                              <div className="flex items-center text-gray-600">
+                                <MapPin className="h-4 w-4 mr-2 text-gray-400" />
+                                <span>
+                                  {lead.location && lead.location !== 'not provided'
+                                    ? lead.location
+                                    : 'No location'}
+                                </span>
+                              </div>
+
+                              {/* Date */}
+                              <div className="flex items-center text-gray-600">
+                                <Calendar className="h-4 w-4 mr-2 text-gray-400" />
+                                <span>{formatDate(lead.created_at)}</span>
+                              </div>
+                            </div>
+                          </div>
+
+                          {/* Expand/Collapse Icon */}
+                          <div className="ml-4 flex-shrink-0">
+                            {isExpanded ? (
+                              <ChevronUp className="h-5 w-5 text-gray-400" />
+                            ) : (
+                              <ChevronDown className="h-5 w-5 text-gray-400" />
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Expanded View - Conversation Summary */}
+                  {isExpanded && (
+                    <div className="border-t border-gray-200 px-4 py-4 bg-gray-50">
+                      <div className="flex items-start">
+                        <MessageSquare className="h-5 w-5 text-gray-400 mt-0.5 mr-3 flex-shrink-0" />
+                        <div className="flex-1">
+                          <h4 className="text-sm font-medium text-gray-900 mb-2">Conversation Summary</h4>
+                          <p className="text-sm text-gray-600 whitespace-pre-wrap">
+                            {lead.conversation_summary || 'No conversation summary available.'}
+                          </p>
+
+                          {/* Additional Details */}
+                          <div className="mt-4 grid grid-cols-2 md:grid-cols-3 gap-4 text-sm">
+                            {lead.job_title && (
+                              <div>
+                                <span className="text-gray-500">Job Title: </span>
+                                <span className="text-gray-900">{lead.job_title}</span>
+                              </div>
+                            )}
+                            {lead.company && (
+                              <div>
+                                <span className="text-gray-500">Company: </span>
+                                <span className="text-gray-900">{lead.company}</span>
+                              </div>
+                            )}
+                            {lead.ai_lead_id && (
+                              <div>
+                                <span className="text-gray-500">Lead ID: </span>
+                                <span className="text-gray-900 text-xs font-mono">
+                                  {lead.ai_lead_id.slice(0, 8)}...
+                                </span>
+                              </div>
+                            )}
+                          </div>
+
+                          {/* Conversation Link */}
+                          {lead.conversation_link && (
+                            <div className="mt-3">
+                              <a
+                                href={`https://${lead.conversation_link}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-sm text-orange-600 hover:text-orange-700"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                View full conversation →
+                              </a>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          )}
         </div>
       </div>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- convert leads page to card-based layout
- add expandable conversation summary with contact details
- support search and status filtering with formatted phone numbers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68add79b2cf48329b6b610ab28ff33a3