### PR TITLE
Add Vitest testing setup and LoginPage tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -42,6 +43,8 @@
     "eslint-plugin-react-refresh": "^0.4.5",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.3.6",
-    "vite": "^5.0.7"
+    "vite": "^5.0.7",
+    "vitest": "^0.34.6",
+    "@testing-library/react": "^14.2.1"
   }
 }

--- a/src/components/__tests__/LoginPage.test.jsx
+++ b/src/components/__tests__/LoginPage.test.jsx
@@ -1,0 +1,65 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { supabase } from '../../lib/supabase';
+import LoginPage from '../LoginPage';
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: {
+    auth: {
+      signInWithPassword: vi.fn().mockResolvedValue({}),
+      signUp: vi.fn().mockResolvedValue({})
+    }
+  }
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('LoginPage', () => {
+  it('renders the login form', () => {
+    render(<LoginPage />);
+    expect(screen.getByPlaceholderText(/email address/i)).toBeTruthy();
+    expect(screen.getByPlaceholderText(/password/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeTruthy();
+  });
+
+  it('submits sign in form', async () => {
+    render(<LoginPage />);
+    fireEvent.input(screen.getByPlaceholderText(/email address/i), {
+      target: { value: 'test@example.com' }
+    });
+    fireEvent.input(screen.getByPlaceholderText(/password/i), {
+      target: { value: 'password' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(supabase.auth.signInWithPassword).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'password'
+      });
+    });
+  });
+
+  it('toggles to sign up and submits', async () => {
+    render(<LoginPage />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /don't have an account\? sign up/i })
+    );
+    fireEvent.input(screen.getByPlaceholderText(/email address/i), {
+      target: { value: 'new@example.com' }
+    });
+    fireEvent.input(screen.getByPlaceholderText(/password/i), {
+      target: { value: 'password' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
+
+    await waitFor(() => {
+      expect(supabase.auth.signUp).toHaveBeenCalledWith({
+        email: 'new@example.com',
+        password: 'password'
+      });
+    });
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,5 +13,8 @@ export default defineConfig({
   server: {
     port: 5173,
     host: true
+  },
+  test: {
+    environment: 'jsdom'
   }
 })


### PR DESCRIPTION
## Summary
- add vitest and @testing-library/react dev dependencies and test script
- configure vitest jsdom environment in Vite config
- create LoginPage tests for rendering and basic submit paths

## Testing
- `npm install` *(fails: 403 Forbidden for @testing-library/react)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fa970ea48329b37279385b309433