### PR TITLE
Style: apply brand colors to login and navigation

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -134,7 +134,7 @@ export default function Layout() {
               to="/"
               className={({ isActive }) =>
                 `nav-item-indicator relative flex items-center px-3 py-2.5 rounded-lg
-    text-gray-700 hover:bg-gray-100/50 transition-colors
+    text-gray-700 hover:bg-gray-900/5 transition-colors
     ${isActive ? 'active' : ''}`
               }
             >
@@ -153,7 +153,7 @@ export default function Layout() {
               to="/leads"
               className={({ isActive }) =>
                 `nav-item-indicator relative flex items-center px-3 py-2.5 rounded-lg
-    text-gray-700 hover:bg-gray-100/50 transition-colors
+    text-gray-700 hover:bg-gray-900/5 transition-colors
     ${isActive ? 'active' : ''}`
               }
             >
@@ -172,7 +172,7 @@ export default function Layout() {
               to="/analytics"
               className={({ isActive }) =>
                 `nav-item-indicator relative flex items-center px-3 py-2.5 rounded-lg
-    text-gray-700 hover:bg-gray-100/50 transition-colors
+    text-gray-700 hover:bg-gray-900/5 transition-colors
     ${isActive ? 'active' : ''}`
               }
             >
@@ -192,7 +192,7 @@ export default function Layout() {
                 to="/scoring"
                 className={({ isActive }) =>
                   `nav-item-indicator relative flex items-center px-3 py-2.5 rounded-lg
-    text-gray-700 hover:bg-gray-100/50 transition-colors
+    text-gray-700 hover:bg-gray-900/5 transition-colors
     ${isActive ? 'active' : ''}`
                 }
               >
@@ -213,7 +213,7 @@ export default function Layout() {
                 to="/chatbots"
                 className={({ isActive }) =>
                   `nav-item-indicator relative flex items-center px-3 py-2.5 rounded-lg
-    text-gray-700 hover:bg-gray-100/50 transition-colors
+    text-gray-700 hover:bg-gray-900/5 transition-colors
     ${isActive ? 'active' : ''}`
                 }
               >
@@ -234,7 +234,7 @@ export default function Layout() {
                 to="/admin"
                 className={({ isActive }) =>
                   `nav-item-indicator relative flex items-center px-3 py-2.5 rounded-lg
-    text-gray-700 hover:bg-gray-100/50 transition-colors
+    text-gray-700 hover:bg-gray-900/5 transition-colors
     ${isActive ? 'active' : ''}`
                 }
               >
@@ -261,7 +261,7 @@ export default function Layout() {
             )}
             <button
               onClick={handleSignOut}
-              className={`w-full flex items-center ${sidebarCollapsed ? 'justify-center' : ''} px-3 py-2 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-100/50 rounded-lg transition-colors`}
+              className={`w-full flex items-center ${sidebarCollapsed ? 'justify-center' : ''} px-3 py-2 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-900/5 rounded-lg transition-colors`}
             >
               <LogOut className="h-4 w-4 flex-shrink-0" />
               {!sidebarCollapsed && <span className="ml-2">Sign Out</span>}

--- a/src/components/LoginPage.jsx
+++ b/src/components/LoginPage.jsx
@@ -40,18 +40,18 @@ export default function LoginPage() {
     };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-orange-500 via-orange-600 to-orange-700 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full space-y-8 bg-white/90 backdrop-blur-sm p-10 rounded-xl shadow-lg">
         <div>
           {/* Your Logo */}
           <div className="flex justify-center mb-8">
-            <img 
-              className="h-24 w-auto" 
-              src={logoUrl} 
+            <img
+              className="h-24 w-auto"
+              src={logoUrl}
               alt="AgentMarket"
             />
           </div>
-          
+
           <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
             {isSignUp ? 'Create your account' : 'Sign in to your account'}
           </h2>
@@ -65,7 +65,7 @@ export default function LoginPage() {
                 required
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-orange-500 focus:border-orange-500 focus:z-10 sm:text-sm"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500 focus:z-10 sm:text-sm transition-colors"
                 placeholder="Email address"
               />
             </div>
@@ -75,7 +75,7 @@ export default function LoginPage() {
                 required
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-orange-500 focus:border-orange-500 focus:z-10 sm:text-sm"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500 focus:z-10 sm:text-sm transition-colors"
                 placeholder="Password"
               />
             </div>
@@ -85,7 +85,7 @@ export default function LoginPage() {
             <button
               type="submit"
               disabled={loading}
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-orange-600 hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500"
+              className="group relative w-full flex justify-center py-2 px-4 text-sm font-medium rounded-md text-white bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 transition-colors"
             >
               {loading ? 'Loading...' : (isSignUp ? 'Sign Up' : 'Sign In')}
             </button>
@@ -95,7 +95,7 @@ export default function LoginPage() {
             <button
               type="button"
               onClick={() => setIsSignUp(!isSignUp)}
-              className="text-sm text-orange-600 hover:text-orange-500"
+              className="text-sm text-orange-600 hover:text-orange-500 transition-colors"
             >
               {isSignUp ? 'Already have an account? Sign In' : "Don't have an account? Sign Up"}
             </button>


### PR DESCRIPTION
## Summary
- Add branded gradient backdrop and card styling to login screen
- Use orange focus rings and gradient call-to-action button
- Soften navigation hover states with a subtle graphite overlay

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b8faed055c8329b22b45464116d1e8