### PR TITLE
Add CI workflow and README instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+      - run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Lead Scoring Dashboard
+
+[![CI](https://github.com/AGNTMKT/agntmkt-dashboard/actions/workflows/ci.yml/badge.svg)](https://github.com/AGNTMKT/agntmkt-dashboard/actions/workflows/ci.yml)
+
+## Getting Started
+
+Install dependencies and start the development server:
+
+```bash
+npm ci
+npm run dev
+```


### PR DESCRIPTION
## Summary
- add CI workflow running install, lint, test, and build steps on pushes and pull requests
- document project with CI status badge and quick start instructions

## Testing
- `npm ci` *(fails: The `npm ci` command can only install with an existing package-lock.json or npm-shrinkwrap.json)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8fb832acc83298a9fc98413ac5ede