### PR TITLE
Improve welcome message preview readability

### DIFF
--- a/src/components/ChatbotBuilder.jsx
+++ b/src/components/ChatbotBuilder.jsx
@@ -1336,7 +1336,9 @@ export default function ChatbotBuilder() {
                               </div>
                               <div className="flex-1 p-4">
                                 <div className="bg-gray-100 rounded-lg p-3">
-                                  <p className="text-sm">{appearanceConfig.welcome_message}</p>
+                                  <p className="text-sm leading-relaxed whitespace-pre-line break-words">
+                                    {appearanceConfig.welcome_message}
+                                  </p>
                                 </div>
                               </div>
                             </div>


### PR DESCRIPTION
## Summary
- improve the chatbot welcome message preview bubble to respect manual line breaks and use relaxed leading for better readability

## Testing
- npm run lint *(fails: ESLint configuration file not found)*

------
https://chatgpt.com/codex/tasks/task_e_690622b2e1b08329aa16294c5eea49cb