### PR TITLE
Enhance auth forms and account settings

### DIFF
--- a/src/components/dashboard/AccountSettings.tsx
+++ b/src/components/dashboard/AccountSettings.tsx
@@ -1,0 +1,293 @@
+// @ts-nocheck
+import React, { FormEvent, useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { cn } from '@/lib/utils';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+function Spinner({ className }: { className?: string }) {
+  return (
+    <svg
+      className={cn('animate-spin', className)}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      />
+    </svg>
+  );
+}
+
+export default function AccountSettings({ className, ...props }) {
+  const [user, setUser] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordStatus, setPasswordStatus] = useState<'idle' | 'saving' | 'success' | 'error'>('idle');
+  const [passwordMessage, setPasswordMessage] = useState<string | null>(null);
+
+  const [newEmail, setNewEmail] = useState('');
+  const [emailStatus, setEmailStatus] = useState<'idle' | 'saving' | 'success' | 'error'>('idle');
+  const [emailMessage, setEmailMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      setUser(data.user);
+      setLoading(false);
+    });
+  }, []);
+
+  const handleChangePassword = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    
+    setPasswordStatus('saving');
+    setPasswordMessage(null);
+
+    if (newPassword !== confirmPassword) {
+      setPasswordStatus('error');
+      setPasswordMessage('Passwords do not match.');
+      return;
+    }
+
+    if (newPassword.length < 6) {
+      setPasswordStatus('error');
+      setPasswordMessage('Password must be at least 6 characters.');
+      return;
+    }
+
+    const { error } = await supabase.auth.updateUser({ password: newPassword });
+
+    if (error) {
+      setPasswordStatus('error');
+      setPasswordMessage(error.message);
+      return;
+    }
+
+    setPasswordStatus('success');
+    setPasswordMessage('Password changed successfully.');
+    setNewPassword('');
+    setConfirmPassword('');
+    
+    setTimeout(() => {
+      setPasswordStatus('idle');
+      setPasswordMessage(null);
+    }, 3000);
+  };
+
+  const handleChangeEmail = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    
+    setEmailStatus('saving');
+    setEmailMessage(null);
+
+    if (!newEmail || !newEmail.includes('@')) {
+      setEmailStatus('error');
+      setEmailMessage('Please enter a valid email address.');
+      return;
+    }
+
+    if (newEmail === user?.email) {
+      setEmailStatus('error');
+      setEmailMessage('New email must be different from current email.');
+      return;
+    }
+
+    const { error } = await supabase.auth.updateUser({ email: newEmail });
+
+    if (error) {
+      setEmailStatus('error');
+      setEmailMessage(error.message);
+      return;
+    }
+
+    setEmailStatus('success');
+    setEmailMessage('Confirmation email sent! Please check both your current and new email addresses to confirm the change.');
+    setNewEmail('');
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center">
+        <Spinner className="h-6 w-6 text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('space-y-6', className)} {...props}>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Profile details</CardTitle>
+            <CardDescription>Manage your personal information.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">Email</span>
+              <span className="font-medium">{user?.email}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">User ID</span>
+              <span className="font-mono text-xs text-muted-foreground">{user?.id}</span>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Account overview</CardTitle>
+            <CardDescription>Review the security of your account.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">Last sign-in</span>
+              <span className="font-medium">{user?.last_sign_in_at ? new Date(user.last_sign_in_at).toLocaleString() : 'N/A'}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">Email confirmed</span>
+              <span className="font-medium">{user?.email_confirmed_at ? 'Yes' : 'Pending'}</span>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Change password</CardTitle>
+          <CardDescription>
+            Update your password to keep your account secure.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleChangePassword}>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="newPassword">New password</Label>
+                <Input
+                  id="newPassword"
+                  type="password"
+                  value={newPassword}
+                  onChange={(event) => setNewPassword(event.target.value)}
+                  placeholder="Enter new password"
+                  autoComplete="new-password"
+                  disabled={passwordStatus === 'saving'}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="confirmPassword">Confirm new password</Label>
+                <Input
+                  id="confirmPassword"
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(event) => setConfirmPassword(event.target.value)}
+                  placeholder="Confirm new password"
+                  autoComplete="new-password"
+                  disabled={passwordStatus === 'saving'}
+                />
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Password must be at least 6 characters long.
+            </p>
+            {passwordMessage && (
+              <div
+                className={cn(
+                  'rounded-md p-3 text-sm',
+                  passwordStatus === 'error' 
+                    ? 'bg-destructive/10 text-destructive' 
+                    : 'bg-emerald-500/10 text-emerald-600'
+                )}
+              >
+                {passwordMessage}
+              </div>
+            )}
+            <Button type="submit" disabled={passwordStatus === 'saving' || !newPassword || !confirmPassword}>
+              {passwordStatus === 'saving' ? (
+                <span className="flex items-center gap-2">
+                  <Spinner className="h-4 w-4" />
+                  Updating...
+                </span>
+              ) : (
+                'Update password'
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Change email address</CardTitle>
+          <CardDescription>
+            Update the email address associated with your account. You&apos;ll need to confirm the change via email.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleChangeEmail}>
+            <div className="space-y-2">
+              <Label htmlFor="currentEmail">Current email</Label>
+              <Input
+                id="currentEmail"
+                type="email"
+                value={user.email ?? ''}
+                disabled
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="newEmail">New email address</Label>
+              <Input
+                id="newEmail"
+                type="email"
+                value={newEmail}
+                onChange={(event) => setNewEmail(event.target.value)}
+                placeholder="Enter new email address"
+                autoComplete="email"
+                disabled={emailStatus === 'saving'}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              A confirmation email will be sent to both your current and new email addresses.
+            </p>
+            {emailMessage && (
+              <div
+                className={cn(
+                  'rounded-md p-3 text-sm',
+                  emailStatus === 'error' 
+                    ? 'bg-destructive/10 text-destructive' 
+                    : 'bg-emerald-500/10 text-emerald-600'
+                )}
+              >
+                {emailMessage}
+              </div>
+            )}
+            <Button type="submit" disabled={emailStatus === 'saving' || !newEmail}>
+              {emailStatus === 'saving' ? (
+                <span className="flex items-center gap-2">
+                  <Spinner className="h-4 w-4" />
+                  Sending...
+                </span>
+              ) : (
+                'Change email'
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/forgot-password-form.tsx
+++ b/src/components/forgot-password-form.tsx
@@ -1,0 +1,125 @@
+// @ts-nocheck
+import React, { useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+function Spinner({ className }: { className?: string }) {
+  return (
+    <svg
+      className={cn('animate-spin', className)}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      />
+    </svg>
+  );
+}
+
+export default function ForgotPasswordForm({ className, ...props }) {
+  const [email, setEmail] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const { error } = await supabase.auth.resetPasswordForEmail(email);
+      if (error) throw error;
+      setSuccess(true);
+    } catch (err: any) {
+      setError(err.message || 'Unable to send reset link');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <div className={cn('mx-auto max-w-md', className)} {...props}>
+        <Card>
+          <CardHeader className="text-center">
+            <img
+              src="https://arqzwjymkdkhhvlvzhap.supabase.co/storage/v1/object/public/Images/OrangeWhite%20AGNT%20Logo.png"
+              alt="AGNTMKT"
+              className="mx-auto mb-4 h-12 w-auto object-contain"
+            />
+            <CardTitle className="text-2xl">Check your email</CardTitle>
+            <CardDescription>
+              We sent a password reset link to <span className="font-medium text-foreground">{email}</span>. If you don&apos;t
+              see it, be sure to check your spam or promotions folder.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('mx-auto max-w-md', className)} {...props}>
+      <Card>
+        <CardHeader className="space-y-2 text-center">
+          <img
+            src="https://arqzwjymkdkhhvlvzhap.supabase.co/storage/v1/object/public/Images/OrangeWhite%20AGNT%20Logo.png"
+            alt="AGNTMKT"
+            className="mx-auto mb-4 h-12 w-auto object-contain"
+          />
+          <CardTitle className="text-2xl">Reset your password</CardTitle>
+          <CardDescription>Enter the email associated with your account</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                placeholder="you@example.com"
+                autoComplete="email"
+                required
+                disabled={isLoading}
+              />
+            </div>
+
+            {error && (
+              <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</div>
+            )}
+
+            <Button type="submit" className="w-full" disabled={isLoading}>
+              {isLoading ? (
+                <span className="flex items-center gap-2">
+                  <Spinner className="h-4 w-4" />
+                  Sending...
+                </span>
+              ) : (
+                'Send reset link'
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -1,0 +1,115 @@
+// @ts-nocheck
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '@/lib/supabase';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+function Spinner({ className }: { className?: string }) {
+  return (
+    <svg
+      className={cn('animate-spin', className)}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      />
+    </svg>
+  );
+}
+
+export default function LoginForm({ className, ...props }) {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleLogin = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const { error } = await supabase.auth.signInWithPassword({ email, password });
+      if (error) throw error;
+
+      navigate('/');
+    } catch (err: any) {
+      setError(err.message || 'Unable to sign in');
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className={cn('mx-auto max-w-md', className)} {...props}>
+      <Card>
+        <CardHeader className="space-y-2 text-center">
+          <CardTitle className="text-2xl">Welcome back</CardTitle>
+          <CardDescription>Sign in to continue to your account</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleLogin}>
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                placeholder="you@example.com"
+                autoComplete="email"
+                required
+                disabled={isLoading}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                placeholder="••••••••"
+                autoComplete="current-password"
+                required
+                disabled={isLoading}
+              />
+            </div>
+
+            {error && (
+              <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</div>
+            )}
+
+            <Button type="submit" className="w-full" disabled={isLoading}>
+              {isLoading ? (
+                <span className="flex items-center gap-2">
+                  <Spinner className="h-4 w-4" />
+                  Signing in...
+                </span>
+              ) : (
+                'Sign in'
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,18 @@
+// @ts-nocheck
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+const baseClasses =
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-orange-600 text-white hover:bg-orange-700 focus-visible:ring-orange-500';
+
+export const Button = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <button ref={ref} className={cn(baseClasses, className)} {...props}>
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = 'Button';

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,23 @@
+// @ts-nocheck
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+export const Card = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('rounded-lg border bg-white text-card-foreground shadow-sm', className)} {...props} />
+);
+
+export const CardHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+);
+
+export const CardTitle = ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+  <h3 className={cn('text-2xl font-semibold leading-none tracking-tight', className)} {...props} />
+);
+
+export const CardDescription = ({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+  <p className={cn('text-sm text-muted-foreground', className)} {...props} />
+);
+
+export const CardContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('p-6 pt-0', className)} {...props} />
+);

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+// @ts-nocheck
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+export const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type = 'text', ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+
+Input.displayName = 'Input';

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,15 @@
+// @ts-nocheck
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+export const Label = React.forwardRef<HTMLLabelElement, React.LabelHTMLAttributes<HTMLLabelElement>>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)}
+      {...props}
+    />
+  )
+);
+
+Label.displayName = 'Label';

--- a/src/components/update-password-form.tsx
+++ b/src/components/update-password-form.tsx
@@ -1,0 +1,199 @@
+// @ts-nocheck
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '@/lib/supabase';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+function Spinner({ className }: { className?: string }) {
+  return (
+    <svg
+      className={cn('animate-spin', className)}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      />
+    </svg>
+  );
+}
+
+export default function UpdatePasswordForm({ className, ...props }) {
+  const navigate = useNavigate();
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleUpdatePassword = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsLoading(true);
+    setError(null);
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      setIsLoading(false);
+      return;
+    }
+
+    if (password.length < 6) {
+      setError('Password must be at least 6 characters');
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const { error } = await supabase.auth.updateUser({ password });
+      if (error) throw error;
+
+      setSuccess(true);
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (user) {
+        const { data: profile } = await supabase
+          .from('user_profiles')
+          .select(`
+      is_agntmkt_team,
+      corporate_accounts (slug)
+    `)
+          .eq('auth_user_id', user.id)
+          .single();
+
+        setTimeout(() => {
+          if (profile?.is_agntmkt_team) {
+            navigate('/admin');
+          } else {
+            const corporateAccounts = profile?.corporate_accounts as { slug: string }[] | null;
+            const orgSlug = corporateAccounts?.[0]?.slug;
+            if (orgSlug) {
+              navigate(`/org/${orgSlug}/dashboard`);
+            } else {
+              navigate('/auth/pending-access');
+            }
+          }
+        }, 1500);
+      } else {
+        setTimeout(() => {
+          navigate('/auth/login');
+        }, 1500);
+      }
+    } catch (err: any) {
+      setError(err.message || 'Unable to update password');
+      setIsLoading(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <div className={cn('flex flex-col gap-6', className)} {...props}>
+        <Card>
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-emerald-500/10">
+              <svg
+                className="h-8 w-8 text-emerald-500"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+            <CardTitle className="text-2xl">Password Updated!</CardTitle>
+            <CardDescription>
+              Your password has been successfully changed. Redirecting you to the dashboard...
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex justify-center">
+            <Spinner className="h-6 w-6 text-muted-foreground" />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('mx-auto max-w-md', className)} {...props}>
+      <Card>
+        <CardHeader className="space-y-2 text-center">
+          <img
+            src="https://arqzwjymkdkhhvlvzhap.supabase.co/storage/v1/object/public/Images/OrangeWhite%20AGNT%20Logo.png"
+            alt="AGNTMKT"
+            className="mx-auto mb-4 h-12 w-auto object-contain"
+          />
+          <CardTitle className="text-2xl">Update your password</CardTitle>
+          <CardDescription>Choose a new password to secure your account</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleUpdatePassword}>
+            <div className="space-y-2">
+              <Label htmlFor="password">New password</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                placeholder="Enter a new password"
+                autoComplete="new-password"
+                required
+                disabled={isLoading}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="confirmPassword">Confirm new password</Label>
+              <Input
+                id="confirmPassword"
+                type="password"
+                value={confirmPassword}
+                onChange={(event) => setConfirmPassword(event.target.value)}
+                placeholder="Confirm your new password"
+                autoComplete="new-password"
+                required
+                disabled={isLoading}
+              />
+            </div>
+
+            {error && (
+              <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</div>
+            )}
+
+            <Button type="submit" className="w-full" disabled={isLoading}>
+              {isLoading ? (
+                <span className="flex items-center gap-2">
+                  <Spinner className="h-4 w-4" />
+                  Updating...
+                </span>
+              ) : (
+                'Update password'
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable Spinner and UI primitives for new auth forms
- implement updated login, forgot password, and password reset flows with loading states and validations
- create account settings view with password and email change workflows

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a7fd520ec8329b1c966c3978427e9)